### PR TITLE
Correctly reject invalid model names and data

### DIFF
--- a/bundles/web/net.enilink.platform.ldp/src/main/scala/net/enilink/platform/ldp/LDPHelper.scala
+++ b/bundles/web/net.enilink.platform.ldp/src/main/scala/net/enilink/platform/ldp/LDPHelper.scala
@@ -296,7 +296,7 @@ class LDPHelper extends RestHelper {
               Globals.fileStore.make.map { fs => fs.delete(key) }
             }
             manager.removeRecursive(requestedUri, true)
-            if (res.getURI == requestedUri) ModelsRest.deleteModel(null, requestedUri)
+            if (res.getURI == requestedUri) new ModelsRest().deleteModel(null, requestedUri)
             val parent = parentUri(requestedUri)
             if (!parent.isEmpty)
               findModel(parent.get).foreach(m => m.getManager.removeRecursive(res.getURI, true))

--- a/bundles/web/net.enilink.platform.lift/pom.xml
+++ b/bundles/web/net.enilink.platform.lift/pom.xml
@@ -114,6 +114,12 @@
 			<version>1.0.0-M2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.liftweb</groupId>
+			<artifactId>lift-testkit_${scala.major.version}</artifactId>
+			<version>3.5.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/bundles/web/net.enilink.platform.web/pom.xml
+++ b/bundles/web/net.enilink.platform.web/pom.xml
@@ -30,6 +30,7 @@
 				<version>${scala.plugin.version}</version>
 				<configuration>
 					<scalaVersion>${scala.version}</scalaVersion>
+					<recompileMode>incremental</recompileMode>
 				</configuration>
 				<executions>
 					<execution>
@@ -65,6 +66,48 @@
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.security</artifactId>
 			<version>1.3.900</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>4.0.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_${scala.major.version}</artifactId>
+			<version>3.1.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalatestplus-junit_${scala.major.version}</artifactId>
+			<version>1.0.0-M2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-core_${scala.major.version}</artifactId>
+			<version>4.16.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-matcher-extra_${scala.major.version}</artifactId>
+			<version>4.16.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-mock_${scala.major.version}</artifactId>
+			<version>4.16.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.liftweb</groupId>
+			<artifactId>lift-testkit_${scala.major.version}</artifactId>
+			<version>3.5.0</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/LiftModule.scala
+++ b/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/LiftModule.scala
@@ -61,7 +61,8 @@ class LiftModule {
       }
     }
 
-    LiftRules.dispatch.append(ModelsRest)
+    LiftRules.dispatch.append(new ModelsRest())
+
     // redirect to HTML presentation if requested by the client (e.g. for a browser)
     LiftRules.statelessRewrite.append({
       case RewriteRequest(

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/ModelsRestSpec.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/ModelsRestSpec.scala
@@ -6,12 +6,82 @@ import net.enilink.komma.model._
 import net.enilink.platform.lift.util.Globals
 import net.liftweb.common.{Box, Full}
 import net.liftweb.http.{LiftResponse, Req}
-import net.liftweb.mocks.MockHttpServletRequest
 import net.liftweb.mockweb.WebSpec
 import org.eclipse.core.runtime.QualifiedName
 import org.eclipse.core.runtime.content.{IContentDescription, IContentType}
 import org.mockito
 import org.specs2.mock.Mockito
+
+import java.io.{ByteArrayInputStream, InputStream}
+import javax.servlet.ServletInputStream
+
+class ModelsRestSpec extends WebSpec(() => {
+  // configure Lift
+  // LiftRules.dispatch.append(MockModelsRest)
+  // create configuration and a model set factory// create configuration and a model set factory
+  val module: KommaModule = ModelPlugin.createModelSetModule(classOf[ModelPlugin].getClassLoader)
+  val factory: IModelSetFactory = Guice.createInjector(new ModelSetModule(module)).getInstance(classOf[IModelSetFactory])
+
+  // create a model set with an in-memory repository
+  val modelSet: IModelSet = factory.createModelSet(MODELS.NAMESPACE_URI.appendFragment("MemoryModelSet"))
+  Globals.contextModelSet.default.set(Full(modelSet))
+}) with Mockito {
+  sequential // This is important for using SessionVars, etc.
+
+  val modelsRest = MockModelsRest
+  val baseUrl = "http://foo.com/models"
+  val testOptionsReq = new MockHttpServletRequest(baseUrl) {
+    method = "OPTIONS"
+  }
+  val testPostReq = new MockHttpServletRequest(baseUrl + "/test-model") {
+    method = "POST"
+    body_=("<t:s> <t:p> <t:o> .", "text/turtle")
+  }
+  val testPostReqToBase = new MockHttpServletRequest(baseUrl) {
+    method = "POST"
+    body_=("<t:s> <t:p> <t:o> .", "text/turtle")
+  }
+  val testGetReq = new MockHttpServletRequest(baseUrl + "/test-model") {
+    method = "GET"
+    headers = (("Accept", "text/turtle" :: Nil) :: Nil).toMap
+  }
+  val testInvalidPostReq = new MockHttpServletRequest(baseUrl + "/test-model-invalid-data") {
+    method = "POST"
+    body_=("<t:s> _invalid_ <t:p> <t:o> .", "text/turtle")
+  }
+
+  "ModelsRest" should {
+    "support options request" withReqFor testOptionsReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 200 => ok
+      }
+    }
+
+    "reject invalid post request to /models" withReqFor testPostReqToBase in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 400 => ok
+      }
+    }
+
+    "support post request" withReqFor testPostReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 200 => ok
+      }
+    }
+
+    "support get request" withReqFor testGetReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 200 => ok
+      }
+    }
+
+    "reject invalid post request" withReqFor testInvalidPostReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 400 => ok
+      }
+    }
+  }
+}
 
 object MockModelsRest extends ModelsRest with Mockito {
   // this class is required to mock the content types which are not working without OSGi
@@ -23,11 +93,11 @@ object MockModelsRest extends ModelsRest with Mockito {
 
     override def getContentType: IContentType = contentType
 
-    override def getProperty(qualifiedName: QualifiedName): AnyRef = {
-      if (qualifiedName.getLocalName == "mimeType") {
-        mimeType._1 + "/" + mimeType._2
-      } else {
-        null
+    override def getProperty(qualifiedName: QualifiedName): Object = {
+      qualifiedName.getLocalName match {
+        case "mimeType" => mimeType._1 + "/" + mimeType._2
+        case "hasWriter" => true: java.lang.Boolean
+        case _ => null
       }
     }
 
@@ -54,49 +124,20 @@ object MockModelsRest extends ModelsRest with Mockito {
   }
 }
 
-class ModelsRestSpec extends WebSpec(() => {
-  // configure Lift
-  // LiftRules.dispatch.append(MockModelsRest)
-  // create configuration and a model set factory// create configuration and a model set factory
-  val module: KommaModule = ModelPlugin.createModelSetModule(classOf[ModelPlugin].getClassLoader)
-  val factory: IModelSetFactory = Guice.createInjector(new ModelSetModule(module)).getInstance(classOf[IModelSetFactory])
+class MockHttpServletRequest(url: String) extends net.liftweb.mocks.MockHttpServletRequest(url) {
+  class MockServletInputStream(is: InputStream) extends ServletInputStream {
+    def read(): Int = is.read()
 
-  // create a model set with an in-memory repository
-  val modelSet: IModelSet = factory.createModelSet(MODELS.NAMESPACE_URI.appendFragment("MemoryModelSet"))
-  Globals.contextModelSet.default.set(Full(modelSet))
-}) with Mockito {
-  sequential // This is important for using SessionVars, etc.
+    override def available(): Int = is.available()
 
-  "ModelsRest" should {
-    val testOptionsUrl = "http://foo.com/models"
-    val testPostUrl = "http://foo.com/models/test"
-    val testGetUrl = "http://foo.com/models"
+    def isFinished(): Boolean = is.available() == 0
 
-    val testOptionsReq = new MockHttpServletRequest(testOptionsUrl) {
-      method = "OPTIONS"
-    }
+    def isReady(): Boolean = !isFinished()
 
-    val modelsRest = MockModelsRest
+    def setReadListener(l: javax.servlet.ReadListener): Unit = ()
+  }
 
-    "support options request" withReqFor testOptionsReq in { req =>
-      modelsRest(req)().map(_.toResponse) must beLike {
-        case Full(r) if r.code == 200 => ok
-      }
-    }
-
-    val testGetReq = new MockHttpServletRequest(testGetUrl) {
-      method = "GET"
-    }
-
-    val testPostReq = new MockHttpServletRequest(testPostUrl) {
-      method = "POST"
-      body_=("<t:s> <t:p> <t:o> .", "text/turtle")
-    }
-
-    "support post request" withReqFor testPostReq in { req =>
-      modelsRest(req)().map(_.toResponse) must beLike {
-        case Full(r) if r.code == 200 => ok
-      }
-    }
+  override def getInputStream(): ServletInputStream = {
+    new MockServletInputStream(new ByteArrayInputStream(body))
   }
 }

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/ModelsRestSpec.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/ModelsRestSpec.scala
@@ -1,0 +1,102 @@
+package net.enilink.platform.web.rest
+
+import com.google.inject.Guice
+import net.enilink.komma.core.KommaModule
+import net.enilink.komma.model._
+import net.enilink.platform.lift.util.Globals
+import net.liftweb.common.{Box, Full}
+import net.liftweb.http.{LiftResponse, Req}
+import net.liftweb.mocks.MockHttpServletRequest
+import net.liftweb.mockweb.WebSpec
+import org.eclipse.core.runtime.QualifiedName
+import org.eclipse.core.runtime.content.{IContentDescription, IContentType}
+import org.mockito
+import org.specs2.mock.Mockito
+
+object MockModelsRest extends ModelsRest with Mockito {
+  // this class is required to mock the content types which are not working without OSGi
+
+  class MockContentDescription(mimeType: (String, String), contentType: IContentType) extends IContentDescription {
+    override def isRequested(qualifiedName: QualifiedName): Boolean = true
+
+    override def getCharset: String = "UTF-8"
+
+    override def getContentType: IContentType = contentType
+
+    override def getProperty(qualifiedName: QualifiedName): AnyRef = {
+      if (qualifiedName.getLocalName == "mimeType") {
+        mimeType._1 + "/" + mimeType._2
+      } else {
+        null
+      }
+    }
+
+    override def setProperty(qualifiedName: QualifiedName, o: Any): Unit = {}
+  }
+
+  override lazy val rdfContentTypes: Map[(String, String), IContentType] = List(
+    createContentType("text", "turtle")
+  ).toMap
+
+  override def apply(in: Req): () => Box[LiftResponse] = {
+    try {
+      Globals.contextModelSet.vend.map(_.getUnitOfWork.begin)
+      super.apply(in)
+    } finally {
+      Globals.contextModelSet.vend.map(_.getUnitOfWork.end)
+    }
+  }
+
+  def createContentType(mimeType: (String, String)): ((String, String), IContentType) = {
+    val contentType = mock[IContentType]
+    mockito.Mockito.when(contentType.getDefaultDescription()).thenReturn(new MockContentDescription(mimeType, contentType))
+    (mimeType, contentType)
+  }
+}
+
+class ModelsRestSpec extends WebSpec(() => {
+  // configure Lift
+  // LiftRules.dispatch.append(MockModelsRest)
+  // create configuration and a model set factory// create configuration and a model set factory
+  val module: KommaModule = ModelPlugin.createModelSetModule(classOf[ModelPlugin].getClassLoader)
+  val factory: IModelSetFactory = Guice.createInjector(new ModelSetModule(module)).getInstance(classOf[IModelSetFactory])
+
+  // create a model set with an in-memory repository
+  val modelSet: IModelSet = factory.createModelSet(MODELS.NAMESPACE_URI.appendFragment("MemoryModelSet"))
+  Globals.contextModelSet.default.set(Full(modelSet))
+}) with Mockito {
+  sequential // This is important for using SessionVars, etc.
+
+  "ModelsRest" should {
+    val testOptionsUrl = "http://foo.com/models"
+    val testPostUrl = "http://foo.com/models/test"
+    val testGetUrl = "http://foo.com/models"
+
+    val testOptionsReq = new MockHttpServletRequest(testOptionsUrl) {
+      method = "OPTIONS"
+    }
+
+    val modelsRest = MockModelsRest
+
+    "support options request" withReqFor testOptionsReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 200 => ok
+      }
+    }
+
+    val testGetReq = new MockHttpServletRequest(testGetUrl) {
+      method = "GET"
+    }
+
+    val testPostReq = new MockHttpServletRequest(testPostUrl) {
+      method = "POST"
+      body_=("<t:s> <t:p> <t:o> .", "text/turtle")
+    }
+
+    "support post request" withReqFor testPostReq in { req =>
+      modelsRest(req)().map(_.toResponse) must beLike {
+        case Full(r) if r.code == 200 => ok
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extends the models REST endpoint with logic to generate errors in case of invalid model names or data.
The PR also introduces a basic unit test for the models endpoint.