### PR TITLE
Improve sparql endpoint error responses with explicit status codes and error codes

### DIFF
--- a/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
+++ b/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
@@ -274,7 +274,7 @@ class SparqlRest extends RestHelper with CorsHelper {
               queryModel(new String(queryData, "UTF-8"), modelUri, mimeType)
             }
           }
-        case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
+        case _ => Full(plainTextResponse(400, "MISSING_QUERY: The request body is empty. Expected a SPARQL query."))
       }
 
     case Nil Post req if S.param("update").isDefined =>
@@ -296,7 +296,7 @@ class SparqlRest extends RestHelper with CorsHelper {
               updateModel(new String(updateData, "UTF-8"), modelUri, mimeType)
             }
           }
-        case _ => Full(plainTextResponse(400, "MISSING_UPDATE: The required parameter 'update' is missing."))
+        case _ => Full(plainTextResponse(400, "MISSING_UPDATE: The request body is empty. Expected a SPARQL update."))
       }
 
     // Fallback: no recognized parameter or content type.

--- a/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
+++ b/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
@@ -180,7 +180,13 @@ class SparqlRest extends RestHelper with CorsHelper {
   }
 
   /**
-   * Convert exception to appropriate HTTP response.
+   * Append the exception's message to a base text, null-safe.
+   */
+  private def withDetail(base: String, t: Throwable): String =
+    Option(t.getMessage).filter(_.nonEmpty).map(m => s"$base $m").getOrElse(base)
+
+  /**
+   * Convert known exception to appropriate HTTP response.
    */
   def toResponse(e: Exception): LiftResponse = {
     // find first cause that is instanceof of RDF4JException
@@ -192,12 +198,12 @@ class SparqlRest extends RestHelper with CorsHelper {
     cause match {
       case mqe: MalformedQueryException =>
         plainTextResponse(400, "MALFORMED_QUERY: " + mqe.getMessage)
-      case _: QueryInterruptedException =>
-        plainTextResponse(503, "QUERY_TIMEOUT: Query execution exceeded the time limit.")
-      case _: QueryEvaluationException =>
-        plainTextResponse(500, "QUERY_EVALUATION_ERROR: Query evaluation failed.")
-      case _: RDF4JException =>
-        plainTextResponse(500, "INTERNAL_ERROR: Internal server error.")
+      case qie: QueryInterruptedException =>
+        plainTextResponse(503, withDetail("QUERY_TIMEOUT: Query execution exceeded the time limit.", qie))
+      case qee: QueryEvaluationException =>
+        plainTextResponse(500, withDetail("QUERY_EVALUATION_ERROR: Query evaluation failed.", qee))
+      case rdf: RDF4JException =>
+        plainTextResponse(500, withDetail("INTERNAL_ERROR: Internal server error.", rdf))
       case _ =>
         plainTextResponse(500, "INTERNAL_ERROR: Internal server error.")
     }
@@ -244,8 +250,11 @@ class SparqlRest extends RestHelper with CorsHelper {
           }
         case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
       }
+
+    // Both 'query' and 'update' present: ambiguous request shape / Conflicting Parameters
     case Nil Post req if S.param("query").isDefined && S.param("update").isDefined =>
-      Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+      Full(plainTextResponse(400, "CONFLICTING_PARAMETERS: 'query' and 'update' cannot be combined in the same request."))
+
     case Nil Post req if S.param("query").isDefined =>
       S.param("query").filter(_.nonEmpty) match {
         case Full(q) =>
@@ -256,6 +265,7 @@ class SparqlRest extends RestHelper with CorsHelper {
           }
         case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
       }
+
     case Nil Post req if req.contentType.exists(_ == "application/sparql-query") =>
       req.body.filter(_.nonEmpty) match {
         case Full(queryData) =>
@@ -264,28 +274,32 @@ class SparqlRest extends RestHelper with CorsHelper {
               queryModel(new String(queryData, "UTF-8"), modelUri, mimeType)
             }
           }
-        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+        case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
       }
+
     case Nil Post req if S.param("update").isDefined =>
       S.param("update").filter(_.nonEmpty) match {
-        case Full(q) =>
+        case Full(u) =>
           withModelUri { modelUri =>
             withResponseMimeType(req) { mimeType =>
-              updateModel(q, modelUri, mimeType)
+              updateModel(u, modelUri, mimeType)
             }
           }
-        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+        case _ => Full(plainTextResponse(400, "MISSING_UPDATE: The required parameter 'update' is missing."))
       }
+
     case Nil Post req if req.contentType.exists(_ == "application/sparql-update") =>
       req.body.filter(_.nonEmpty) match {
-        case Full(queryData) =>
+        case Full(updateData) =>
           withModelUri { modelUri =>
             withResponseMimeType(req) { mimeType =>
-              updateModel(new String(queryData, "UTF-8"), modelUri, mimeType)
+              updateModel(new String(updateData, "UTF-8"), modelUri, mimeType)
             }
           }
-        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+        case _ => Full(plainTextResponse(400, "MISSING_UPDATE: The required parameter 'update' is missing."))
       }
+
+    // Fallback: no recognized parameter or content type.
     case Nil Post _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
   })
 }

--- a/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
+++ b/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
@@ -58,8 +58,9 @@ class SparqlRest extends RestHelper with CorsHelper {
    * Handle SPARQL queries against a model.
    */
   def queryModel(queryStr: String, modelUri: URI, resultMimeType: String): Box[LiftResponse] = {
-    getModel(modelUri).dmap(Full(NotFoundResponse("Model " + modelUri + " not found.")): Box[LiftResponse]) {
-      case model@NotAllowedModel(_) => Full(ForbiddenResponse("You don't have permissions to access " + model.getURI + "."))
+    getModel(modelUri).dmap(Full(plainTextResponse(404, "MODEL_NOT_FOUND: No model found for the given identifier.")): Box[LiftResponse]) {
+      case model@NotAllowedModel(_) =>
+        Full(plainTextResponse(403, "FORBIDDEN: You don't have permissions to access " + model.getURI + "."))
       case model =>
         try {
           val em = model.getManager
@@ -153,8 +154,9 @@ class SparqlRest extends RestHelper with CorsHelper {
    * Handle SPARQL updates against a model.
    */
   def updateModel(queryStr: String, modelUri: URI, resultMimeType: String): Box[LiftResponse] = {
-    getModel(modelUri).dmap(Full(NotFoundResponse("Model " + modelUri + " not found.")): Box[LiftResponse]) {
-      case model@NotAllowedModel(_) => Full(ForbiddenResponse("You don't have permissions to access " + model.getURI + "."))
+    getModel(modelUri).dmap(Full(plainTextResponse(404, "MODEL_NOT_FOUND: No model found for the given identifier.")): Box[LiftResponse]) {
+      case model@NotAllowedModel(_) =>
+        Full(plainTextResponse(403, "FORBIDDEN: You don't have permissions to access " + model.getURI + "."))
       case model =>
         val em = model.getManager
         val changeSupport = model.getModelSet.getDataChangeSupport
@@ -188,77 +190,45 @@ class SparqlRest extends RestHelper with CorsHelper {
     }
 
     cause match {
-      case mqe: MalformedQueryException => plainTextBadRequest("MALFORMED_QUERY: " + mqe.getMessage)
+      case mqe: MalformedQueryException =>
+        plainTextResponse(400, "MALFORMED_QUERY: " + mqe.getMessage)
       case _: QueryInterruptedException =>
-        plainTextServiceUnavailable("QUERY_TIMEOUT: Query execution exceeded the time limit.")
+        plainTextResponse(503, "QUERY_TIMEOUT: Query execution exceeded the time limit.")
       case _: QueryEvaluationException =>
-        plainTextInternalServerError("QUERY_EVALUATION_ERROR: Query evaluation failed.")
+        plainTextResponse(500, "QUERY_EVALUATION_ERROR: Query evaluation failed.")
       case _: RDF4JException =>
-        plainTextInternalServerError("INTERNAL_ERROR: Internal server error.")
+        plainTextResponse(500, "INTERNAL_ERROR: Internal server error.")
       case _ =>
-        plainTextInternalServerError("INTERNAL_ERROR: Internal server error.")
+        plainTextResponse(500, "INTERNAL_ERROR: Internal server error.")
     }
-  }
-
-  private def plainTextBadRequest(message: String): LiftResponse = {
-    plainTextResponse(400, message)
-  }
-
-  private def plainTextNotAcceptable(message: String): LiftResponse = {
-    plainTextResponse(406, message)
-  }
-
-  private def plainTextServiceUnavailable(message: String): LiftResponse = {
-    plainTextResponse(503, message)
-  }
-
-  private def plainTextInternalServerError(message: String): LiftResponse = {
-    plainTextResponse(500, message)
   }
 
   private def plainTextResponse(status: Int, message: String): LiftResponse = {
     InMemoryResponse(message.getBytes("UTF-8"), "Content-Type" -> "text/plain; charset=utf-8" :: responseHeaders, responseCookies, status)
   }
 
-  private def missingModelResponse: LiftResponse =
-    plainTextBadRequest("MISSING_MODEL: The required parameter 'model' is missing.")
-
-  private def missingQueryResponse: LiftResponse =
-    plainTextBadRequest("MISSING_QUERY: The required parameter 'query' is missing.")
-
-  private def invalidQueryRequestResponse: LiftResponse =
-    plainTextBadRequest("INVALID_QUERY_REQUEST: The query request structure is invalid.")
-
-  private def modelNotFoundResponse: LiftResponse =
-    NotFoundResponse("MODEL_NOT_FOUND: No model found for the given identifier.")
-
-  private def unsupportedAcceptResponse: LiftResponse =
-    plainTextNotAcceptable("UNSUPPORTED_ACCEPT: The requested result format is not supported.")
-
   private def withResponseMimeType(req: Req)(f: String => Box[LiftResponse]): Box[LiftResponse] = {
     getSparqlQueryResponseMimeType(req) match {
       case Full(mimeType) => f(mimeType)
-      case _ => Full(unsupportedAcceptResponse)
+      case _ => Full(plainTextResponse(406, "UNSUPPORTED_ACCEPT: The requested result format is not supported."))
     }
   }
 
-  private def withRequestedModel(req: Req)(f: IModel => Box[LiftResponse]): Box[LiftResponse] = {
+  private def withModelUri(f: URI => Box[LiftResponse]): Box[LiftResponse] = {
     S.param("model").filter(_.nonEmpty) match {
       case Full(modelName) =>
-        try {
-          val modelUri = URIs.createURI(modelName)
-          if (modelUri.isRelative) {
-            Full(modelNotFoundResponse)
-          } else {
-            getModel(modelUri).dmap(Full(modelNotFoundResponse): Box[LiftResponse]) {
-              case model@NotAllowedModel(_) => Full(ForbiddenResponse("You don't have permissions to access " + model.getURI + "."))
-              case model => f(model)
-            }
-          }
+        // try/catch is scoped to URI parsing only; f(uri) runs outside it
+        val uriOpt = try {
+          val uri = URIs.createURI(modelName)
+          if (uri.isRelative) None else Some(uri)
         } catch {
-          case _: Exception => Full(modelNotFoundResponse)
+          case _: Exception => None
         }
-      case _ => Full(missingModelResponse)
+        uriOpt match {
+          case Some(uri) => f(uri)
+          case None => Full(plainTextResponse(404, "MODEL_NOT_FOUND: No model found for the given identifier."))
+        }
+      case _ => Full(plainTextResponse(400, "MISSING_MODEL: The required parameter 'model' is missing."))
     }
   }
 
@@ -267,59 +237,55 @@ class SparqlRest extends RestHelper with CorsHelper {
     case Nil Get req =>
       S.param("query").filter(_.nonEmpty) match {
         case Full(query) =>
-          withRequestedModel(req) { model =>
+          withModelUri { modelUri =>
             withResponseMimeType(req) { mimeType =>
-              queryModel(query, model.getURI, mimeType)
+              queryModel(query, modelUri, mimeType)
             }
           }
-        case _ => Full(missingQueryResponse)
+        case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
       }
     case Nil Post req if S.param("query").isDefined && S.param("update").isDefined =>
-      Full(invalidQueryRequestResponse)
-    case Nil Post req if S.param("query").isDefined => {
-      val query = S.param("query")
-      query flatMap { q =>
-        withRequestedModel(req) { model =>
-          withResponseMimeType(req) { mimeType =>
-            queryModel(q, model.getURI, mimeType)
-          }
-        }
-      }
-    }
-    case Nil Post req if req.contentType.exists(_ == "application/sparql-query") => {
-      req.body.filter(_.nonEmpty) match {
-        case Full(queryData) =>
-          withRequestedModel(req) { model =>
+      Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+    case Nil Post req if S.param("query").isDefined =>
+      S.param("query").filter(_.nonEmpty) match {
+        case Full(q) =>
+          withModelUri { modelUri =>
             withResponseMimeType(req) { mimeType =>
-              val query = new String(queryData, "UTF-8")
-              queryModel(query, model.getURI, mimeType)
+              queryModel(q, modelUri, mimeType)
             }
           }
-        case _ => Full(invalidQueryRequestResponse)
+        case _ => Full(plainTextResponse(400, "MISSING_QUERY: The required parameter 'query' is missing."))
       }
-    }
-    case Nil Post req if S.param("update").isDefined => {
-      val query = S.param("update")
-      query flatMap { q =>
-        withRequestedModel(req) { model =>
-          withResponseMimeType(req) { mimeType =>
-            updateModel(q, model.getURI, mimeType)
-          }
-        }
-      }
-    }
-    case Nil Post req if req.contentType.exists(_ == "application/sparql-update") => {
+    case Nil Post req if req.contentType.exists(_ == "application/sparql-query") =>
       req.body.filter(_.nonEmpty) match {
         case Full(queryData) =>
-          withRequestedModel(req) { model =>
+          withModelUri { modelUri =>
             withResponseMimeType(req) { mimeType =>
-              val query = new String(queryData, "UTF-8")
-              updateModel(query, model.getURI, mimeType)
+              queryModel(new String(queryData, "UTF-8"), modelUri, mimeType)
             }
           }
-        case _ => Full(invalidQueryRequestResponse)
+        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
       }
-    }
-    case Nil Post _ => Full(invalidQueryRequestResponse)
+    case Nil Post req if S.param("update").isDefined =>
+      S.param("update").filter(_.nonEmpty) match {
+        case Full(q) =>
+          withModelUri { modelUri =>
+            withResponseMimeType(req) { mimeType =>
+              updateModel(q, modelUri, mimeType)
+            }
+          }
+        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+      }
+    case Nil Post req if req.contentType.exists(_ == "application/sparql-update") =>
+      req.body.filter(_.nonEmpty) match {
+        case Full(queryData) =>
+          withModelUri { modelUri =>
+            withResponseMimeType(req) { mimeType =>
+              updateModel(new String(queryData, "UTF-8"), modelUri, mimeType)
+            }
+          }
+        case _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
+      }
+    case Nil Post _ => Full(plainTextResponse(400, "INVALID_QUERY_REQUEST: The query request structure is invalid."))
   })
 }

--- a/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
+++ b/bundles/web/net.enilink.platform.web/src/main/scala/net/enilink/platform/web/rest/SparqlRest.scala
@@ -1,17 +1,17 @@
 package net.enilink.platform.web.rest
 
 import net.enilink.komma.core._
-import net.enilink.komma.model.{IModelSet, ModelUtil}
+import net.enilink.komma.model.{IModel, IModelSet, ModelUtil}
 import net.enilink.komma.rdf4j.RDF4JValueConverter
 import net.enilink.platform.lift.rest.CorsHelper
 import net.enilink.platform.lift.util.{Globals, NotAllowedModel}
 import net.liftweb.common.{Box, Full}
 import net.liftweb.http.rest.RestHelper
-import net.liftweb.http.{InMemoryResponse, LiftResponse, OutputStreamResponse, S}
+import net.liftweb.http.{InMemoryResponse, LiftResponse, OutputStreamResponse, Req, S}
 import net.liftweb.util.Helpers.tryo
 import org.eclipse.rdf4j.common.exception.RDF4JException
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
-import org.eclipse.rdf4j.query.MalformedQueryException
+import org.eclipse.rdf4j.query.{MalformedQueryException, QueryEvaluationException, QueryInterruptedException}
 import org.eclipse.rdf4j.query.resultio.{QueryResultIO, QueryResultWriter}
 import org.eclipse.rdf4j.rio.WriterConfig
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings
@@ -188,62 +188,138 @@ class SparqlRest extends RestHelper with CorsHelper {
     }
 
     cause match {
-      case mqe: MalformedQueryException => BadRequestResponse("Invalid query:\n" + mqe.getMessage)
-      case null => InternalServerErrorResponse()
+      case mqe: MalformedQueryException => plainTextBadRequest("MALFORMED_QUERY: " + mqe.getMessage)
+      case _: QueryInterruptedException =>
+        plainTextServiceUnavailable("QUERY_TIMEOUT: Query execution exceeded the time limit.")
+      case _: QueryEvaluationException =>
+        plainTextInternalServerError("QUERY_EVALUATION_ERROR: Query evaluation failed.")
+      case _: RDF4JException =>
+        plainTextInternalServerError("INTERNAL_ERROR: Internal server error.")
+      case _ =>
+        plainTextInternalServerError("INTERNAL_ERROR: Internal server error.")
+    }
+  }
+
+  private def plainTextBadRequest(message: String): LiftResponse = {
+    plainTextResponse(400, message)
+  }
+
+  private def plainTextNotAcceptable(message: String): LiftResponse = {
+    plainTextResponse(406, message)
+  }
+
+  private def plainTextServiceUnavailable(message: String): LiftResponse = {
+    plainTextResponse(503, message)
+  }
+
+  private def plainTextInternalServerError(message: String): LiftResponse = {
+    plainTextResponse(500, message)
+  }
+
+  private def plainTextResponse(status: Int, message: String): LiftResponse = {
+    InMemoryResponse(message.getBytes("UTF-8"), "Content-Type" -> "text/plain; charset=utf-8" :: responseHeaders, responseCookies, status)
+  }
+
+  private def missingModelResponse: LiftResponse =
+    plainTextBadRequest("MISSING_MODEL: The required parameter 'model' is missing.")
+
+  private def missingQueryResponse: LiftResponse =
+    plainTextBadRequest("MISSING_QUERY: The required parameter 'query' is missing.")
+
+  private def invalidQueryRequestResponse: LiftResponse =
+    plainTextBadRequest("INVALID_QUERY_REQUEST: The query request structure is invalid.")
+
+  private def modelNotFoundResponse: LiftResponse =
+    NotFoundResponse("MODEL_NOT_FOUND: No model found for the given identifier.")
+
+  private def unsupportedAcceptResponse: LiftResponse =
+    plainTextNotAcceptable("UNSUPPORTED_ACCEPT: The requested result format is not supported.")
+
+  private def withResponseMimeType(req: Req)(f: String => Box[LiftResponse]): Box[LiftResponse] = {
+    getSparqlQueryResponseMimeType(req) match {
+      case Full(mimeType) => f(mimeType)
+      case _ => Full(unsupportedAcceptResponse)
+    }
+  }
+
+  private def withRequestedModel(req: Req)(f: IModel => Box[LiftResponse]): Box[LiftResponse] = {
+    S.param("model").filter(_.nonEmpty) match {
+      case Full(modelName) =>
+        try {
+          val modelUri = URIs.createURI(modelName)
+          if (modelUri.isRelative) {
+            Full(modelNotFoundResponse)
+          } else {
+            getModel(modelUri).dmap(Full(modelNotFoundResponse): Box[LiftResponse]) {
+              case model@NotAllowedModel(_) => Full(ForbiddenResponse("You don't have permissions to access " + model.getURI + "."))
+              case model => f(model)
+            }
+          }
+        } catch {
+          case _: Exception => Full(modelNotFoundResponse)
+        }
+      case _ => Full(missingModelResponse)
     }
   }
 
   serve("sparql" :: Nil prefix {
     case Nil Options _ => OkResponse()
     case Nil Get req =>
-      for {
-        query <- S.param("query")
-        model <- Globals.contextModel.vend
-        mimeType <- getSparqlQueryResponseMimeType(req)
-
-        result <- queryModel(query, model.getURI, mimeType)
-      } yield result
+      S.param("query").filter(_.nonEmpty) match {
+        case Full(query) =>
+          withRequestedModel(req) { model =>
+            withResponseMimeType(req) { mimeType =>
+              queryModel(query, model.getURI, mimeType)
+            }
+          }
+        case _ => Full(missingQueryResponse)
+      }
+    case Nil Post req if S.param("query").isDefined && S.param("update").isDefined =>
+      Full(invalidQueryRequestResponse)
     case Nil Post req if S.param("query").isDefined => {
       val query = S.param("query")
       query flatMap { q =>
-        for {
-          model <- Globals.contextModel.vend
-          mimeType <- getSparqlQueryResponseMimeType(req)
-
-          result <- queryModel(q, model.getURI, mimeType)
-        } yield result
+        withRequestedModel(req) { model =>
+          withResponseMimeType(req) { mimeType =>
+            queryModel(q, model.getURI, mimeType)
+          }
+        }
       }
     }
     case Nil Post req if req.contentType.exists(_ == "application/sparql-query") => {
-      for {
-        mimeType <- getSparqlQueryResponseMimeType(req)
-        queryData <- req.body
-        query = new String(queryData, "UTF-8")
-        model <- Globals.contextModel.vend
-
-        result <- queryModel(query, model.getURI, mimeType)
-      } yield result
+      req.body.filter(_.nonEmpty) match {
+        case Full(queryData) =>
+          withRequestedModel(req) { model =>
+            withResponseMimeType(req) { mimeType =>
+              val query = new String(queryData, "UTF-8")
+              queryModel(query, model.getURI, mimeType)
+            }
+          }
+        case _ => Full(invalidQueryRequestResponse)
+      }
     }
     case Nil Post req if S.param("update").isDefined => {
       val query = S.param("update")
       query flatMap { q =>
-        for {
-          model <- Globals.contextModel.vend
-          mimeType <- getSparqlQueryResponseMimeType(req)
-
-          result <- updateModel(q, model.getURI, mimeType)
-        } yield result
+        withRequestedModel(req) { model =>
+          withResponseMimeType(req) { mimeType =>
+            updateModel(q, model.getURI, mimeType)
+          }
+        }
       }
     }
     case Nil Post req if req.contentType.exists(_ == "application/sparql-update") => {
-      for {
-        mimeType <- getSparqlQueryResponseMimeType(req)
-        queryData <- req.body
-        query = new String(queryData, "UTF-8")
-        model <- Globals.contextModel.vend
-
-        result <- updateModel(query, model.getURI, mimeType)
-      } yield result
+      req.body.filter(_.nonEmpty) match {
+        case Full(queryData) =>
+          withRequestedModel(req) { model =>
+            withResponseMimeType(req) { mimeType =>
+              val query = new String(queryData, "UTF-8")
+              updateModel(query, model.getURI, mimeType)
+            }
+          }
+        case _ => Full(invalidQueryRequestResponse)
+      }
     }
+    case Nil Post _ => Full(invalidQueryRequestResponse)
   })
 }

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
@@ -130,7 +130,7 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertPlainTextError(response, 400, "MISSING_QUERY: The required parameter 'query' is missing.")
+    assertPlainTextError(response, 400, "MISSING_QUERY: The request body is empty. Expected a SPARQL query.")
   }
 
   @Test
@@ -143,7 +143,7 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertPlainTextError(response, 400, "MISSING_UPDATE: The required parameter 'update' is missing.")
+    assertPlainTextError(response, 400, "MISSING_UPDATE: The request body is empty. Expected a SPARQL update.")
   }
 
   @Test

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
@@ -121,7 +121,7 @@ class SparqlRestTest {
   }
 
   @Test
-  def postSparqlQueryWithEmptyBodyIsRejected(): Unit = {
+  def postSparqlQueryWithEmptyBodyReturnsMissingQuery(): Unit = {
     val req = new MockHttpServletRequest(baseUrl) {
       method = "POST"
       parameters = List("model" -> SparqlRestTest.testModel.toString)
@@ -130,11 +130,11 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+    assertPlainTextError(response, 400, "MISSING_QUERY: The required parameter 'query' is missing.")
   }
 
   @Test
-  def postSparqlUpdateWithEmptyBodyIsRejected(): Unit = {
+  def postSparqlUpdateWithEmptyBodyReturnsMissingUpdate(): Unit = {
     val req = new MockHttpServletRequest(baseUrl) {
       method = "POST"
       parameters = List("model" -> SparqlRestTest.testModel.toString)
@@ -143,7 +143,7 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+    assertPlainTextError(response, 400, "MISSING_UPDATE: The required parameter 'update' is missing.")
   }
 
   @Test
@@ -184,7 +184,7 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+    assertPlainTextError(response, 400, "CONFLICTING_PARAMETERS:")
   }
 
   @Test
@@ -233,18 +233,27 @@ class SparqlRestTest {
   def interruptedQueryMapsToQueryTimeoutEnvelope(): Unit = {
     val response = new SparqlRest().toResponse(new Exception(new QueryInterruptedException("timed out")))
     assertPlainTextError(Some(response.toResponse), 503, "QUERY_TIMEOUT: Query execution exceeded the time limit.")
+    // underlying message should be appended
+    val body = responseToString(response.toResponse.asInstanceOf[BasicResponse])
+    assertTrue(body.contains("timed out"), s"Expected underlying message in body, got: $body")
   }
 
   @Test
   def evaluationFailureMapsToQueryEvaluationEnvelope(): Unit = {
     val response = new SparqlRest().toResponse(new Exception(new QueryEvaluationException("evaluation failed")))
+    // assert the stable prefix, then the detail separately (robust to RDF4J wording changes)
     assertPlainTextError(Some(response.toResponse), 500, "QUERY_EVALUATION_ERROR: Query evaluation failed.")
+    val body = responseToString(response.toResponse.asInstanceOf[BasicResponse])
+    assertTrue(body.contains("evaluation failed"), s"Expected underlying message in body, got: $body")
   }
 
   @Test
   def nonRdf4jFailureMapsToInternalErrorEnvelope(): Unit = {
     val response = new SparqlRest().toResponse(new RuntimeException("boom"))
     assertPlainTextError(Some(response.toResponse), 500, "INTERNAL_ERROR: Internal server error.")
+    // unknown exception details must NOT be leaked
+    val body = responseToString(response.toResponse.asInstanceOf[BasicResponse])
+    assertFalse(body.contains("boom"), s"Unknown exception message should not be leaked, got: $body")
   }
 
   @Test

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
@@ -3,12 +3,16 @@ package net.enilink.platform.web.rest
 import com.google.inject.Guice
 import net.enilink.komma.core.{KommaModule, Statement, URI, URIs}
 import net.enilink.komma.model._
+import net.enilink.platform.core.security.ISecureModelSet
 import net.enilink.platform.lift.util.Globals
 import net.liftweb.common.{Box, Full}
 import net.liftweb.http.provider.servlet.HTTPRequestServlet
 import net.liftweb.http.{BasicResponse, InMemoryResponse, LiftResponse, OutputStreamResponse, Req}
 import org.junit.jupiter.api.{AfterAll, BeforeAll, Test}
 import org.junit.jupiter.api.Assertions._
+import org.eclipse.rdf4j.query.{MalformedQueryException, QueryEvaluationException, QueryInterruptedException}
+import org.mockito.ArgumentMatchers.{any => mAny, eq => mEq}
+import org.mockito.Mockito
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
@@ -69,6 +73,211 @@ class SparqlRestTest {
   }
 
   @Test
+  def queryWithoutModel(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List("query" -> "SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "MISSING_MODEL: The required parameter 'model' is missing.")
+  }
+
+  @Test
+  def postQueryWithoutModel(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List("query" -> "SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
+      contentType = "application/x-www-form-urlencoded"
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "MISSING_MODEL: The required parameter 'model' is missing.")
+  }
+
+  @Test
+  def queryWithoutQueryParameter(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List("model" -> SparqlRestTest.testModel.toString)
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "MISSING_QUERY: The required parameter 'query' is missing.")
+  }
+
+  @Test
+  def malformedQueryUsesPlainTextEnvelope(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List(
+        "query" -> "SELECT WHERE { ?s ?p ?o }",
+        "model" -> SparqlRestTest.testModel.toString
+      )
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "MALFORMED_QUERY:")
+  }
+
+  @Test
+  def postSparqlQueryWithEmptyBodyIsRejected(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List("model" -> SparqlRestTest.testModel.toString)
+      contentType = "application/sparql-query"
+      body = Array.emptyByteArray
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+  }
+
+  @Test
+  def postSparqlUpdateWithEmptyBodyIsRejected(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List("model" -> SparqlRestTest.testModel.toString)
+      contentType = "application/sparql-update"
+      body = Array.emptyByteArray
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+  }
+
+  @Test
+  def postWithoutQueryOrUpdateIsRejected(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List("model" -> SparqlRestTest.testModel.toString)
+      contentType = "application/x-www-form-urlencoded"
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+  }
+
+  @Test
+  def unsupportedPostContentTypeIsRejected(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List("model" -> SparqlRestTest.testModel.toString)
+      contentType = "text/plain"
+      body = "SELECT ?s WHERE { ?s ?p ?o }".getBytes(StandardCharsets.UTF_8)
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+  }
+
+  @Test
+  def conflictingQueryAndUpdateShapeIsRejected(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "POST"
+      parameters = List(
+        "query" -> "SELECT ?s WHERE { ?s ?p ?o }",
+        "update" -> "INSERT DATA { <t:s3> <t:p3> <t:o3> }",
+        "model" -> SparqlRestTest.testModel.toString
+      )
+      contentType = "application/x-www-form-urlencoded"
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 400, "INVALID_QUERY_REQUEST: The query request structure is invalid.")
+  }
+
+  @Test
+  def invalidModelUriReturnsModelNotFound(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List(
+        "query" -> "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+        "model" -> "not a valid uri"
+      )
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 404, "MODEL_NOT_FOUND: No model found for the given identifier.")
+  }
+
+  @Test
+  def unknownModelReturnsNotFound(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List(
+        "query" -> "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+        "model" -> MODELS.NAMESPACE_URI.appendFragment("missing-model").toString
+      )
+      headers = Map("Accept" -> List("application/sparql-results+json"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertEquals(404, response.map(_.code).getOrElse(-1))
+    val body = response.map(responseToString).getOrElse("")
+    assertTrue(body.startsWith("MODEL_NOT_FOUND: No model found for the given identifier."), s"Unexpected body: $body")
+  }
+
+  @Test
+  def unsupportedAcceptHeaderReturnsExplicitError(): Unit = {
+    val req = new MockHttpServletRequest(baseUrl) {
+      method = "GET"
+      parameters = List(
+        "query" -> "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+        "model" -> SparqlRestTest.testModel.toString
+      )
+      headers = Map("Accept" -> List("application/x-unsupported-result"))
+    }
+    val response = sparqlRest(toReq(req))().map(_.toResponse)
+    assertPlainTextError(response, 406, "UNSUPPORTED_ACCEPT: The requested result format is not supported.")
+  }
+
+  @Test
+  def interruptedQueryMapsToQueryTimeoutEnvelope(): Unit = {
+    val response = new SparqlRest().toResponse(new Exception(new QueryInterruptedException("timed out")))
+    assertPlainTextError(Some(response.toResponse), 503, "QUERY_TIMEOUT: Query execution exceeded the time limit.")
+  }
+
+  @Test
+  def evaluationFailureMapsToQueryEvaluationEnvelope(): Unit = {
+    val response = new SparqlRest().toResponse(new Exception(new QueryEvaluationException("evaluation failed")))
+    assertPlainTextError(Some(response.toResponse), 500, "QUERY_EVALUATION_ERROR: Query evaluation failed.")
+  }
+
+  @Test
+  def nonRdf4jFailureMapsToInternalErrorEnvelope(): Unit = {
+    val response = new SparqlRest().toResponse(new RuntimeException("boom"))
+    assertPlainTextError(Some(response.toResponse), 500, "INTERNAL_ERROR: Internal server error.")
+  }
+
+  @Test
+  def malformedQueryInNestedCauseStillMapsToMalformedEnvelope(): Unit = {
+    val response = new SparqlRest().toResponse(new RuntimeException("outer", new MalformedQueryException("syntax")))
+    assertPlainTextError(Some(response.toResponse), 400, "MALFORMED_QUERY:")
+  }
+
+  @Test
+  def forbiddenModelAccessStillReturns403(): Unit = {
+    val forbiddenModelUri = MODELS.NAMESPACE_URI.appendFragment("forbidden-model")
+    val contextModelSet = Mockito.mock(classOf[IModelSet])
+    val secureModelSet = Mockito.mock(classOf[ISecureModelSet])
+    val model = Mockito.mock(classOf[IModel])
+
+    Mockito.when(contextModelSet.getModel(mEq(forbiddenModelUri), mEq(false))).thenReturn(model)
+    Mockito.when(model.getURI).thenReturn(forbiddenModelUri)
+    Mockito.when(model.getModelSet).thenReturn(secureModelSet)
+    Mockito.when(secureModelSet.isReadableBy(mAny(), mAny())).thenReturn(false)
+
+    Globals.contextModelSet.default.set(Full(contextModelSet))
+    try {
+      val response = new SparqlRest().queryModel("SELECT ?s WHERE { ?s ?p ?o }", forbiddenModelUri, "application/sparql-results+json")
+        .map(_.toResponse)
+      assertPlainTextError(response, 403, "You don't have permissions to access")
+    } finally {
+      Globals.contextModelSet.default.set(Full(SparqlRestTest.modelSet))
+    }
+  }
+
+  @Test
   def constructQuery(): Unit = {
     val req = new MockHttpServletRequest(baseUrl) {
       method = "GET"
@@ -126,5 +335,15 @@ class SparqlRestTest {
         rStream.toString()
       case _ => fail("Unexpected response type"); ""
     }
+  }
+
+  def assertPlainTextError(response: Option[BasicResponse], expectedCode: Int, expectedPrefix: String): Unit = {
+    assertEquals(expectedCode, response.map(_.code).getOrElse(-1))
+    val contentType = response
+      .flatMap(_.headers.find(_._1.equalsIgnoreCase("Content-Type")).map(_._2))
+      .getOrElse("")
+    assertTrue(contentType.toLowerCase.startsWith("text/plain"), s"Expected text/plain content type but got: '$contentType'")
+    val body = response.map(responseToString).getOrElse("")
+    assertTrue(body.startsWith(expectedPrefix), s"Expected prefix '$expectedPrefix' but got: $body")
   }
 }

--- a/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
+++ b/bundles/web/net.enilink.platform.web/src/test/scala/net/enilink/platform/web/rest/SparqlRestTest.scala
@@ -212,9 +212,7 @@ class SparqlRestTest {
       headers = Map("Accept" -> List("application/sparql-results+json"))
     }
     val response = sparqlRest(toReq(req))().map(_.toResponse)
-    assertEquals(404, response.map(_.code).getOrElse(-1))
-    val body = response.map(responseToString).getOrElse("")
-    assertTrue(body.startsWith("MODEL_NOT_FOUND: No model found for the given identifier."), s"Unexpected body: $body")
+    assertPlainTextError(response, 404, "MODEL_NOT_FOUND: No model found for the given identifier.")
   }
 
   @Test
@@ -271,7 +269,7 @@ class SparqlRestTest {
     try {
       val response = new SparqlRest().queryModel("SELECT ?s WHERE { ?s ?p ?o }", forbiddenModelUri, "application/sparql-results+json")
         .map(_.toResponse)
-      assertPlainTextError(response, 403, "You don't have permissions to access")
+      assertPlainTextError(response, 403, "FORBIDDEN: You don't have permissions to access")
     } finally {
       Globals.contextModelSet.default.set(Full(SparqlRestTest.modelSet))
     }


### PR DESCRIPTION
### Summary

Resolves #30. The SPARQL endpoint now returns `text/plain` responses with
explicit HTTP status codes and prefixed error codes for all common failure
cases, as discussed and agreed on in the issue thread.


### Error Contract

| Condition | Status | Response Body Prefix |
|---|---|---|
| Missing `model` parameter | 400 | `MISSING_MODEL:` |
| Invalid or unknown model | 404 | `MODEL_NOT_FOUND:` |
| Forbidden model access | 403 | `FORBIDDEN:` |
| Missing `query` parameter | 400 | `MISSING_QUERY:` |
| Invalid request shape¹ | 400 | `INVALID_QUERY_REQUEST:` |
| Malformed SPARQL syntax | 400 | `MALFORMED_QUERY:` |
| Unsupported Accept header | 406 | `UNSUPPORTED_ACCEPT:` |
| Query timeout | 503 | `QUERY_TIMEOUT:` |
| Query evaluation failure | 500 | `QUERY_EVALUATION_ERROR:` |
| Other server errors | 500 | `INTERNAL_ERROR:` |

¹ Empty POST body, conflicting query+update, unsupported content type.

### What Changed

- All error responses go through a single `plainTextResponse` helper
  that includes CORS headers consistently.
- `model` is now a required query parameter (no longer read from session).
- `withModelUri` validates the parameter and URI format before dispatching.
- `withResponseMimeType` rejects unsupported Accept headers explicitly.
- RDF4J exceptions are mapped to specific status codes instead of
  falling through to the container's generic 500 page.
- Added a catch-all `POST` route so unmatched requests get a clear 400.

### Testing

- 17 new unit tests in `SparqlRestTest.scala` covering all error paths
  in the table above, plus the existing happy-path tests (SELECT,
  CONSTRUCT, ASK, UPDATE) which now pass the `model` parameter explicitly.
- Includes a Mockito-backed test for 403 Forbidden to verify the new
  error handling doesn't bypass existing authorization logic.
- Tests were written first to see if they detect, and then implementation was added .
- Added Tests to linkedfactory-pod instance → corresponding linkedfactory-pod branch with updates: https://github.com/linkedfactory/linkedfactory-pod/compare/main...36-misleading-http-status-codes-at-sparql-when-wrongmissing-model-and-missing-query
  - Tests in LF-Pod fail now on GitHub, but locally tested, that with the new enilink tests go through → Need to be rerun, once enilnk here is merged and built.

### Design Decisions

- **Single `MODEL_NOT_FOUND` for both invalid URIs and missing models:**
  Avoids leaking information about which URI patterns the system accepts.
- **No `INVALID_MODEL` / `INVALID_MODEL_URI` as separate codes:**
  Collapsed into `MODEL_NOT_FOUND` for the same security reason. The client action is the same either way.
- **`text/plain` only, no JSON:** Per discussion in #30, following the W3C SPARQL Protocol examples.